### PR TITLE
Add oEmbed support to gh pages site

### DIFF
--- a/webserial/index.html
+++ b/webserial/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>OPT4048 CIE Color Plotter</title>
   <!-- oEmbed Discovery Links -->
-  <link rel="alternate" type="application/json+oembed" href="https://adafruit.github.io/Adafruit_OPT4048/oembed.json" title="Adafruit OPT4048 Demo" />
+  <link rel="alternate" type="application/json+oembed" href="https://adafruit.github.io/Adafruit_OPT4048/webserial/oembed.json" title="Adafruit OPT4048 Demo" />
   <style>
     body {
       font-family: Arial, sans-serif;

--- a/webserial/index.html
+++ b/webserial/index.html
@@ -4,6 +4,8 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>OPT4048 CIE Color Plotter</title>
+  <!-- oEmbed Discovery Links -->
+  <link rel="alternate" type="application/json+oembed" href="https://adafruit.github.io/Adafruit_OPT4048/oembed.json" title="Adafruit OPT4048 Demo" />
   <style>
     body {
       font-family: Arial, sans-serif;

--- a/webserial/oembed.json
+++ b/webserial/oembed.json
@@ -1,0 +1,12 @@
+{
+  "version": "1.0",
+  "type": "rich",
+  "title": "Adafruit OPT4048 Library",
+  "provider_name": "Adafruit",
+  "provider_url": "https://www.adafruit.com",
+  "author_name": "Adafruit",
+  "author_url": "https://github.com/adafruit",
+  "width": 800,
+  "height": 600,
+  "html": "<iframe src='https://adafruit.github.io/Adafruit_OPT4048/' width='800' height='600' style='border: 1px solid #ddd; border-radius: 4px; max-width: 100%;' allow='serial; usb' loading='lazy' title='Adafruit OPT4048 Arduino Library'></iframe>"
+}

--- a/webserial/oembed.json
+++ b/webserial/oembed.json
@@ -8,5 +8,5 @@
   "author_url": "https://github.com/adafruit",
   "width": 800,
   "height": 600,
-  "html": "<iframe src='https://adafruit.github.io/Adafruit_OPT4048/' width='800' height='600' style='border: 1px solid #ddd; border-radius: 4px; max-width: 100%;' allow='serial; usb' loading='lazy' title='Adafruit OPT4048 Arduino Library'></iframe>"
+  "html": "<iframe src='https://adafruit.github.io/Adafruit_OPT4048/webserial/' width='800' height='600' style='border: 1px solid #ddd; border-radius: 4px; max-width: 100%;' allow='serial; usb' loading='lazy' title='Adafruit OPT4048 Arduino Library'></iframe>"
 }


### PR DESCRIPTION
This adds the oembed.json response expected when a site visits the <link> tag for oembed information in the main page (also added).
Maybe worth adjusting the height/width, and other things, I'm not 100% sure how compatible the 'serial; usb' permissions on the iframe are YMMV (testing on chrome windows + android).